### PR TITLE
Archive download instead of git for ceph submodules - Remove submodules git sync

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -11,15 +11,6 @@ outfile="ceph-$version"
 
 echo "version $version"
 
-# update submodules
-echo "updating submodules..."
-force=$(if git submodule usage 2>&1 | grep --quiet 'update.*--force'; then echo --force ; fi)
-if ! git submodule sync || ! git submodule update $force --init --recursive; then
-    echo "Error: could not initialize submodule projects"
-    echo "  Network connectivity might be required."
-    exit 1
-fi
-
 download_boost() {
     boost_version=$1
     shift


### PR DESCRIPTION
Archive download can keep file mirrors instead of git checkout when build each time, which is more maintainable and stable way.
We have some changes on stx-integ, stx-tools, stx-manifest, and remove the git submodules sync operations.