### PR TITLE
ceph: mon down not detected because ceph health detail output changed

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -353,7 +353,7 @@ is_process_hung() {
      elif [ "$type" = "mon" ]; then
         # Get monitor status info
         local mon_status=$UP
-        echo "$CEPH_HEALTH_DETAIL" | grep -q -e "^$name.*down"
+        echo "$CEPH_HEALTH_DETAIL" | grep -q -e "^[[:space:]]*$name.*down"
         if [ $? -eq 0 ]; then
             mon_status=$DOWN
         fi


### PR DESCRIPTION
"ceph health detail" monitor down status line is indented.
The "status" script does not expect any whitespace at the
beginning of the line so it doesn't properly identify the
monitor as "down".